### PR TITLE
Capture stdout and stderr of go list separately

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -38,7 +38,7 @@ func (bdr *builder) build() (string, error) {
 
 	for _, pkg := range bdr.pkgs {
 		log.Printf("Building %s for %s/%s\n", pkg, bdr.platform.os, bdr.platform.arch)
-		bs, err := exec.Command("go", "list", "-f", "{{.Name}}", pkg).CombinedOutput()
+		bs, err := exec.Command("go", "list", "-f", "{{.Name}}", pkg).Output()
 		if err != nil {
 			return "", errors.Errorf("go list failed with following output: %q", string(bs))
 		}


### PR DESCRIPTION
Because go list outputs the log for go modules to stderr.
```
[goxz] [!!ERROR!!] can't build artifact for non main package: "go: finding github.com/davecgh/go-spew v1.1.1\ngo: finding github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98
e3ecb4b0\ngo: finding github.com/stretchr/testify v1.3.0\ngo: finding github.com/davecgh/go-spew v1.1.0\ngo: finding github.com/stretchr/objx v0.1.0\ngo: finding github.com/pmezard/
go-difflib v1.0.0\ngo: downloading github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0\ngo: extracting github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3e
cb4b0\nmain"
```