### PR TITLE
[bugfix] fix output path in windows

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -60,6 +60,9 @@ func (bdr *builder) build() (string, error) {
 				}
 				output = filepath.Base(wd)
 			}
+			if bdr.platform.os == "windows" {
+				output += ".exe"
+			}
 		}
 		cmdArgs := []string{"build", "-o", filepath.Join(workDir, output)}
 		if bdr.buildLdFlags != "" {


### PR DESCRIPTION
bugged after v0.3.0.

In the case of windows, it is necessary to explicitly give the .exe extension.

reported at https://github.com/motemen/ghq/issues/138