### PR TITLE
Do not use -Hwindowsgui

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -71,9 +71,7 @@ func (bdr *builder) build() (string, error) {
 			var flags string
 			if bdr.static {
 				switch bdr.platform.os {
-				case "windows":
-					flags = `-H=windowsgui -extldflags "-static"`
-				case "freebsd", "netbsd", "linux":
+				case "freebsd", "netbsd", "linux", "windows":
 					flags = `-extldflags "-static"`
 				case "darwin":
 					flags = `-s -extldflags "-sectcreate __TEXT __info_plist Info.plist"`


### PR DESCRIPTION
See https://github.com/motemen/ghq/issues/272

On Windows, the PE header for GUI is not same as CLI's one. `-Hwindowsgui` is a flag for building GUI application (not for CLI's one). If `-Hwindowsgui` is provided for CLI app, command-prompt window always show-up popup windows for CLI app.

https://twitter.com/mattn_jp/status/1219659705879941121