### PR TITLE
Add -trimpath option

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -22,7 +22,7 @@ type builder struct {
 	buildLdFlags, buildTags, buildInstallSuffix string
 	pkgs                                        []string
 	workDirBase                                 string
-	zipAlways, static                           bool
+	zipAlways, static, trimpath                 bool
 	resources                                   []string
 	projDir                                     string
 }
@@ -110,6 +110,9 @@ func (bdr *builder) build() (string, error) {
 			if tags != "" {
 				cmdArgs = append(cmdArgs, "-tags", tags)
 			}
+		}
+		if bdr.trimpath {
+			cmdArgs = append(cmdArgs, "-trimpath")
 		}
 		if bdr.buildInstallSuffix != "" {
 			cmdArgs = append(cmdArgs, "-installsuffix", bdr.buildInstallSuffix)

--- a/cli.go
+++ b/cli.go
@@ -58,6 +58,7 @@ Options:
 
 	fs.BoolVar(&gx.static, "static", false, "build statically linked binary")
 	fs.BoolVar(&gx.work, "work", false, "[for debug] print the name of the temporary work directory and do not delete it when exiting.")
+	fs.BoolVar(&gx.trimpath, "trimpath", false, "remove all file system paths from the resulting executable. requires Go 1.13 or later.")
 
 	err := fs.Parse(args)
 	if err != nil {

--- a/goxz.go
+++ b/goxz.go
@@ -30,6 +30,7 @@ type goxz struct {
 	pkgs                                        []string
 	static                                      bool
 	work                                        bool
+	trimpath                                    bool
 
 	platforms []*platform
 	projDir   string
@@ -265,6 +266,7 @@ func (gx *goxz) builders() []*builder {
 			zipAlways:          gx.zipAlways,
 			static:             gx.static,
 			workDirBase:        gx.workDir,
+			trimpath:           gx.trimpath,
 			resources:          gx.resources,
 			projDir:            gx.projDir,
 		}


### PR DESCRIPTION
@Songmu 

This PR enables to use `-trimpath` option.


I have one consultation.

The `-trimpath` option is supported since Go 1.13, so if execution environment is not Go 1.13 or later, I think `goxz` should ignore the `-trimpath` option even if it is specified.

Could you give me some advice on how to implement it?

