### PR TITLE
Use deflate algorithm for zip archives

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -148,13 +148,17 @@ func (bdr *builder) build() (string, error) {
 		}
 	}
 
-	var arch archiver.Archiver = &archiver.Zip{
-		CompressionLevel:     flate.DefaultCompression,
-		MkdirAll:             true,
-		SelectiveCompression: true,
-	}
-	archiveFilePath := workDir + ".zip"
-	if !bdr.zipAlways && bdr.platform.os != "windows" && bdr.platform.os != "darwin" {
+	var arch archiver.Archiver
+	var archiveFilePath string
+	if bdr.zipAlways || bdr.platform.os == "windows" || bdr.platform.os == "darwin" {
+		arch = &archiver.Zip{
+			CompressionLevel:     flate.DefaultCompression,
+			MkdirAll:             true,
+			SelectiveCompression: true,
+			FileMethod:           archiver.Deflate,
+		}
+		archiveFilePath = workDir + ".zip"
+	} else {
 		arch = &archiver.TarGz{
 			CompressionLevel: gzip.DefaultCompression,
 			Tar: &archiver.Tar{


### PR DESCRIPTION
This PR fixes #32 by specifying the compression algorithm to Deflate. The regression is caused by https://github.com/mholt/archiver/commit/d44471c49aa75c23b8835fa77ccf8718f8d526b8, which allows configuration of compression algorithm. I also tried to configure compression levels but it does not significantly decrease the archive size, so didn't include in this patch.

<img width="808" alt="goxz" src="https://user-images.githubusercontent.com/375258/166886134-c9832e0a-78cc-4aa6-acf4-001e5bb44a46.png">

