### PR TITLE
docs(readme): add users info

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@main

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 goxz
 =======
 
+[![Network Dependents](https://dependents.info/Songmu/goxz/badge)](dependents-info)
 [![Build Status](https://github.com/Songmu/goxz/workflows/test/badge.svg?branch=main)][actions]
 [![Coverage Status](https://codecov.io/gh/Songmu/goxz/branch/main/graph/badge.svg)][codecov]
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)][license]
 [![GoDev](https://pkg.go.dev/badge/github.com/Songmu/goxz)][godev]
 
+[dependents-info]: https://dependents.info/Songmu/goxz
 [actions]: https://github.com//Songmu/goxz/actions?workflow=test
 [codecov]: https://codecov.io/gh/Songmu/goxz
 [license]: https://github.com/Songmu/goxz/blob/main/LICENSE
@@ -16,6 +18,12 @@ GO + X (crossbuild) + Z (zip)
 ## Description
 
 Just do cross building and archiving go tools conventionally
+
+## Used by
+
+<a href="https://dependents.info/Songmu/goxz">
+  <img src="https://dependents.info/Songmu/goxz/image" />
+</a>
 
 ## Installation
 


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR adds a relevant auto-updated shields.io style network dependents badge and the image in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago. It also creates an image preview of the users in the readme.

Here's how they would look for your repository:

<img width="688" alt="image" src="https://github.com/user-attachments/assets/cb3600a9-dc30-48f0-a8bf-7ed7abc5418f" />

Please feel free to close the PR if you don't want to have this!